### PR TITLE
Fix wrong logical operator

### DIFF
--- a/verify_dataset.py
+++ b/verify_dataset.py
@@ -29,7 +29,7 @@ def test_triplets(root):
         img_paths = sorted(city.glob('*.*'), key=get_coords)
         for key, group in itertools.groupby(img_paths, key=get_coords):
             group = list(group)
-            if len(group) != 3 or len(group) != 4:
+            if len(group) != 3 and len(group) != 4:
                 print('missing a file in {}: {}'.format(city.name, [g.name for g in group]))
 
 root = 'dataset'


### PR DESCRIPTION
To test that RGB, DEM and Seg. are there,
the logical operator should be ``and``, nor ``or``.

example:
if there are 
``476_5767_rgb.jp2``, ``476_5767_dem.tif``, ``476_5767_seg.tif`` files in ``bielefeld/`` folder,
then triplet is formed as below:
```python
group=['476_5767_rgb.jp2', '476_5767_dem.tif', '476_5767_seg.tif']

len(group)=3
```
and 

```python
if len(group) != 3 or len(group) != 4:
    print('missing a file in {}: {}'.format(city.name, [g.name for g in group]))
```
operation produces always True.
So I fix it as below.

```python
if len(group) != 3 and len(group) != 4:
    print('missing a file in {}: {}'.format(city.name, [g.name for g in group]))
```